### PR TITLE
Enable cors for e2e tests - they are needed for testcafe to work prop…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+* Enable cors in DataServer only for development and end to end testing
+
 ## [4.3.8]
 
 ### Fixed

--- a/src/socket/DataServer.test.ts
+++ b/src/socket/DataServer.test.ts
@@ -4,6 +4,8 @@ import { getPorts } from '../common/utils'
 test('start and stop data server', async () => {
   const ports = await getPorts()
   const dataServer = new DataServer(ports.dataServer)
+  // @ts-expect-error
+  expect(dataServer.io.engine.opts.cors).toBe(false) // No cors should be set by default
   await dataServer.listen()
   await dataServer.close()
 })

--- a/src/socket/DataServer.ts
+++ b/src/socket/DataServer.ts
@@ -23,8 +23,8 @@ export class DataServer {
     if (process.env.NODE_ENV === 'development' && process.env.E2E_TEST === 'true') {
       log('Development/test env. Getting cors')
       return {
-        origin: "*",
-        methods: ["GET", "POST"]
+        origin: '*',
+        methods: ['GET', 'POST']
       }
     }
     return {}

--- a/src/socket/DataServer.ts
+++ b/src/socket/DataServer.ts
@@ -27,7 +27,7 @@ export class DataServer {
         methods: ['GET', 'POST']
       }
     }
-    return {}
+    return false
   }
 
   private readonly initSocket = (): void => {

--- a/src/socket/DataServer.ts
+++ b/src/socket/DataServer.ts
@@ -1,6 +1,7 @@
 import express from 'express'
 import { createServer, Server } from 'http'
 import logger from '../logger'
+import cors from 'cors'
 // eslint-disable-next-line
 const socketio = require('socket.io')
 const log = logger('socket')
@@ -13,12 +14,26 @@ export class DataServer {
   constructor(port?: number) {
     this.PORT = port || 4677
     this._app = express()
+    this._app.use(cors())
     this.server = createServer(this._app)
     this.initSocket()
   }
 
+  private get cors() {
+    if (process.env.NODE_ENV === 'development' && process.env.E2E_TEST === 'true') {
+      log('Development/test env. Getting cors')
+      return {
+        origin: "*",
+        methods: ["GET", "POST"]
+      }
+    }
+    return {}
+  }
+
   private readonly initSocket = (): void => {
-    this.io = socketio(this.server)
+    this.io = socketio(this.server, {
+      cors: this.cors
+    })
   }
 
   public listen = async (): Promise<void> => {


### PR DESCRIPTION
…erly